### PR TITLE
Add helm url from secret

### DIFF
--- a/helm/templates/task.yaml
+++ b/helm/templates/task.yaml
@@ -17,6 +17,7 @@ spec:
       description: Path to the helmchart relative to workingDir
     - name: REGISTRY
       type: string
+      default: "NA"
     - name: PR_NUMBER
       type: string
       default: NA

--- a/helm/templates/task.yaml
+++ b/helm/templates/task.yaml
@@ -44,6 +44,12 @@ spec:
           name: $(params.HELM_REG_CREDS_SECRET_NAME)  
           key: username
           optional: true
+    - name: REG_URL
+      valueFrom:
+        secretKeyRef:
+          name: $(params.HELM_REG_CREDS_SECRET_NAME)
+          key: url
+          optional: true
     image: ghcr.io/stakater/pipeline-toolbox:v0.0.37
     name: helm-package
     command: ["/bin/bash"]
@@ -55,9 +61,14 @@ spec:
           if [ $(params.PR_NUMBER) == "NA" ]; then
              VERSION=$(inputs.params.SEM_VER)
              CHART_PACKAGE="$(helm package --version $VERSION -u $(params.CHART_PATH) | cut -d":" -f2 | tr -d '[:space:]')"
-             echo Uploading $CHART_PACKAGE to $(params.REGISTRY)
-             curl -u "${REG_USER}":"${REG_PASSWORD}" $(params.REGISTRY) --upload-file "$CHART_PACKAGE"
-           echo "Helm chart successfully pushed"
+             if [ $(params.REGISTRY) != "NA" ]; then
+               echo Uploading $CHART_PACKAGE to $(params.REGISTRY)
+               curl -u "${REG_USER}":"${REG_PASSWORD}" $(params.REGISTRY) --upload-file "$CHART_PACKAGE"        
+             else
+                echo Uploading $CHART_PACKAGE to "${REG_URL}"
+                curl -u "${REG_USER}":"${REG_PASSWORD}" ${REG_URL} --upload-file "$CHART_PACKAGE"        
+             fi
+             echo "Helm chart successfully pushed"
           else
               echo "Its a PR"
           fi


### PR DESCRIPTION
Instead of the developer having to provide the url through a parameter, we want to inject the helm url from a secret. The option for provided another hardcoded url is still available. It takes precedence over the url from secret if provided. Default value for the url param is NA